### PR TITLE
Race AIの調整

### DIFF
--- a/Assets/Demos/Demo_Kurokawa/PlayerScript/WayPointChecker.cs
+++ b/Assets/Demos/Demo_Kurokawa/PlayerScript/WayPointChecker.cs
@@ -11,6 +11,7 @@ public class WayPointChecker : MonoBehaviour
     private Vector3 m_nextWayPointPos = Vector3.zero;           //次のウェイポイントの座標
     private int m_nextWayPointNumber = 0;                       //次のウェイポイントの番号
     private Transform m_nextWayPointTransform = null;           //次のウェイポイントのTrasnform
+    private float m_nextWayPointHalfWidth = 0.0f;
 
     // Start is called before the first frame update
     void Start()
@@ -23,6 +24,8 @@ public class WayPointChecker : MonoBehaviour
             //次のウェイポイントの座標を取得
             m_nextWayPointPos = nextWayPoint.transform.position;
             m_nextWayPointTransform = nextWayPoint.transform;
+            //次のウェイポイントの幅の半分の長さを取得
+            m_nextWayPointHalfWidth = nextWayPoint.gameObject.GetComponent<BoxCollider>().size.x / 2.0f;
         }
 
         //Playerタグ(AI)だったら
@@ -33,6 +36,8 @@ public class WayPointChecker : MonoBehaviour
             //次のウェイポイントの座標を取得
             m_nextWayPointPos = nextWayPoint.transform.position;
             m_nextWayPointTransform = nextWayPoint.transform;
+            //次のウェイポイントの幅の半分の長さを取得
+            m_nextWayPointHalfWidth = nextWayPoint.gameObject.GetComponent<BoxCollider>().size.x / 2.0f;
         }
     }
 
@@ -52,6 +57,11 @@ public class WayPointChecker : MonoBehaviour
     public int GetNextWayPointNumber()
     {
         return m_nextWayPointNumber;
+    }
+
+    public float GetNextWayPointHalfWidth()
+    {
+        return m_nextWayPointHalfWidth;
     }
 
     //次のウェイポイントの右方向を返す
@@ -106,6 +116,9 @@ public class WayPointChecker : MonoBehaviour
 
         //新しいポイントのトランスフォームを取得
         m_nextWayPointTransform = nextWayPoint.transform;
+
+        //新しいポイントの当たり判定の幅の半分の長さを取得
+        m_nextWayPointHalfWidth = nextWayPoint.gameObject.GetComponent<BoxCollider>().size.x / 2.0f;
 
         if (this.gameObject.tag == "OwnPlayer"
             && !PhotonNetwork.OfflineMode)

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/AIPlayer.prefab
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/AIPlayer.prefab
@@ -80,11 +80,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AITag: Player
   m_playerTag: OwnPlayer
+  m_AIDifficulty: {fileID: 11400000, guid: bb9defb917d71194c85f41800fbc2a50, type: 2}
   m_obstacleLayerMask:
     serializedVersion: 2
     m_Bits: 32768
-  m_innerShiftMaxLength: 5
-  m_outerShiftMaxLength: 3
+  m_maxMoveRatio: 0.2
 --- !u!114 &15993647147685149
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty.meta
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3b7bac2ec5764f4bb21cc74153c71f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AIDifficulty.cs
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AIDifficulty.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "ScriptableObjects/AIDifficulty")]
+public class SpawnManagerScriptableObject : ScriptableObject
+{
+    //内側の何割の幅まで目標地点になり得るか
+    [Range(-1.0f,1.0f)]
+    public float innerShiftMaxRatio;
+
+    //外側の何割の幅まで目標地点になり得るか
+    [Range(-1.0f, 1.0f)]
+    public float outerShiftMaxRatio;
+}

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AIDifficulty.cs
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AIDifficulty.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(menuName = "ScriptableObjects/AIDifficulty")]
-public class SpawnManagerScriptableObject : ScriptableObject
+public class AIDifficulty : ScriptableObject
 {
     //“à‘¤‚Ì‰½Š„‚Ì•‚Ü‚Å–Ú•W’n“_‚É‚È‚è“¾‚é‚©
     [Range(-1.0f,1.0f)]

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AIDifficulty.cs.meta
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AIDifficulty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b08fef62b4b79b247a602a763d9f739c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Easy.asset
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Easy.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: AI_Easy
+  m_EditorClassIdentifier: Assembly-CSharp::SpawnManagerScriptableObject
+  innerShiftMaxRatio: 0
+  outerShiftMaxRatio: 0

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Easy.asset
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Easy.asset
@@ -9,8 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 0}
+  m_Script: {fileID: 11500000, guid: b08fef62b4b79b247a602a763d9f739c, type: 3}
   m_Name: AI_Easy
-  m_EditorClassIdentifier: Assembly-CSharp::SpawnManagerScriptableObject
-  innerShiftMaxRatio: 0
-  outerShiftMaxRatio: 0
+  m_EditorClassIdentifier: 
+  innerShiftMaxRatio: 1
+  outerShiftMaxRatio: 1

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Easy.asset.meta
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Easy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8106319a612175469b84393d490f090
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Hard.asset
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Hard.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: AI_Hard
+  m_EditorClassIdentifier: Assembly-CSharp::SpawnManagerScriptableObject
+  innerShiftMaxRatio: 0
+  outerShiftMaxRatio: 0

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Hard.asset
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Hard.asset
@@ -9,8 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 0}
+  m_Script: {fileID: 11500000, guid: b08fef62b4b79b247a602a763d9f739c, type: 3}
   m_Name: AI_Hard
-  m_EditorClassIdentifier: Assembly-CSharp::SpawnManagerScriptableObject
-  innerShiftMaxRatio: 0
-  outerShiftMaxRatio: 0
+  m_EditorClassIdentifier: 
+  innerShiftMaxRatio: 1
+  outerShiftMaxRatio: -0.5

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Hard.asset.meta
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Hard.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad4b0610640df0249a85eba02f184804
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Normal.asset
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Normal.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: AI_Normal
+  m_EditorClassIdentifier: Assembly-CSharp::SpawnManagerScriptableObject
+  innerShiftMaxRatio: 0
+  outerShiftMaxRatio: 0

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Normal.asset
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Normal.asset
@@ -9,8 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 0}
+  m_Script: {fileID: 11500000, guid: b08fef62b4b79b247a602a763d9f739c, type: 3}
   m_Name: AI_Normal
-  m_EditorClassIdentifier: Assembly-CSharp::SpawnManagerScriptableObject
-  innerShiftMaxRatio: 0
-  outerShiftMaxRatio: 0
+  m_EditorClassIdentifier: 
+  innerShiftMaxRatio: 1
+  outerShiftMaxRatio: 0.25

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Normal.asset.meta
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/Difficulty/AI_Normal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb9defb917d71194c85f41800fbc2a50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/RaceAIScript.cs
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/RaceAIScript.cs
@@ -27,12 +27,12 @@ public class RaceAIScript : MonoBehaviour
     //運の良さ?
 
 
+    private float m_shiftLength = 0.0f;                                         //目指す地点がウェイポイントから右方向にどれだけ離れているか
     private Vector3 m_targetOffset = new Vector3(0.0f,0.0f,0.0f);               //現在の目標のウェイポイントからずらす幅
     private int m_targetNumber = -1;                                            //現在目標にしているウェイポイントの番号
 
 
     //障害物避け用変数
-    private float m_shiftLength = 0;                                            //目指す地点がウェイポイントから右方向にどれだけ離れているか
     public LayerMask m_obstacleLayerMask;                                       //障害物のレイヤーマスク
     RaycastHit m_sphereCastHit;                                                 //SphereCastの結果を格納する変数
     float m_sphereCastRadius = 1.0f;                                            //SphereCastの半径
@@ -41,8 +41,9 @@ public class RaceAIScript : MonoBehaviour
 
 
     //ウェイポイントから目標地点をずらす幅(コースによって幅が違うためウェイポイント側への実装も検討)
-    public float m_innerShiftMaxLength = 5.0f;//内側への最大のずらし幅
+    public float m_innerShiftMaxLength = 4.0f;//内側への最大のずらし幅
     public float m_outerShiftMaxLength = 3.0f;//外側への最大のずらし幅
+    private float m_currentShiftRatio = 0.5f;//現在のずらし幅の割合(内側:0.0f～外側:1.0f)
 
     //AIはウェイポイントとの距離に応じてどの角度以内ならハンドルを切るかを変化させる
     //例:
@@ -131,8 +132,17 @@ public class RaceAIScript : MonoBehaviour
             this.GetComponent<AICommunicator>().SetNextWayPoint(m_targetNumber);
         }
 
-        //ウェイポイントの座標からずらす幅を乱数で決定
-        m_shiftLength = Random.Range(-m_innerShiftMaxLength, m_outerShiftMaxLength);
+        //現在のウェイポイントの座標からずらす割合に変化を与える値を乱数で決定
+        float moveRatio = Random.Range(-0.2f, 0.2f);
+
+        //現在の割合に加算
+        m_currentShiftRatio += moveRatio;
+
+        //0~1に整える(規定値より内・外にいかないように)
+        m_currentShiftRatio = Mathf.Clamp01(m_currentShiftRatio);
+
+        //割合から実際にずらす長さを計算
+        m_shiftLength = Mathf.Lerp(-m_innerShiftMaxLength, m_outerShiftMaxLength, m_currentShiftRatio);
 
         //目指す位置をローカル座標系で左右にずらすベクトルを計算
         m_targetOffset = m_wayPointChecker.GetNextWayPointRight() * m_shiftLength;

--- a/Assets/Demos/Demo_Nishikiori/RaceAI/RaceAIScript.cs
+++ b/Assets/Demos/Demo_Nishikiori/RaceAI/RaceAIScript.cs
@@ -11,6 +11,7 @@ public class RaceAIScript : MonoBehaviour
     public string m_playerTag = "OwnPlayer";                                    //プレイヤーにつけられたゲームオブジェクトのタグ
     private Rigidbody m_rigidbody = null;                                       //AIキャラクターの剛体
     private WayPointChecker m_wayPointChecker = null;                           //AIキャラクターのウェイポイントチェッカー
+    public AIDifficulty m_AIDifficulty = null;
 
     //ステータス//
     //スピード
@@ -138,8 +139,8 @@ public class RaceAIScript : MonoBehaviour
         nextHalfWidth -= 2.0f;
 
         //内外に取りうる値の最大値をウェイポイントの幅と難易度から設定
-        float innerShiftMaxLength = nextHalfWidth;// * (AI難易度による内側への割合);
-        float outerShiftMaxLength = nextHalfWidth;// * (AI難易度による外側への割合);
+        float innerShiftMaxLength = nextHalfWidth * m_AIDifficulty.innerShiftMaxRatio;
+        float outerShiftMaxLength = nextHalfWidth * m_AIDifficulty.outerShiftMaxRatio;
 
 
 

--- a/Assets/Photon/PhotonUnityNetworking/Resources/AI.prefab
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/AI.prefab
@@ -174,11 +174,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AITag: Player
   m_playerTag: OwnPlayer
+  m_AIDifficulty: {fileID: 11400000, guid: bb9defb917d71194c85f41800fbc2a50, type: 2}
   m_obstacleLayerMask:
     serializedVersion: 2
     m_Bits: 32768
-  m_innerShiftMaxLength: 5
-  m_outerShiftMaxLength: 3
+  m_maxMoveRatio: 0.2
 --- !u!114 &-6493101101817206569
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
ステージの幅が変更される事に対応するために、ウェイポイントの幅からAIの目的地のずらし具合を決めるように。
スクリプタブルオブジェクトからAIの難易度を設定できるように(実際にタイトルから設定できるようにはなっていない)